### PR TITLE
fix: focus issue with nexted contenteditables on touch devices

### DIFF
--- a/src/use-prevent-scroll.ts
+++ b/src/use-prevent-scroll.ts
@@ -199,7 +199,7 @@ function preventScrollMobileSafari({ skipTouchEndHandling }: { skipTouchEndHandl
     let target = e.target as HTMLElement;
 
     // Apply this change if we're not already focused on the target element
-    if (isInput(target) && target !== document.activeElement) {
+    if (isInput(target) && document.activeElement.contains(target)) {
       e.preventDefault();
 
       // Apply a transform to trick Safari into thinking the input is at the top of the page


### PR DESCRIPTION
Simple example: editor which uses contenteditable. Like Quill. Quill creates a nested <p> element inside the div.ql-editor[contenteditable=true]. For some reasons `isContentEditable` for such a <p> will return `true`, thus making `isInput` to be true in `onTouchEnd` handler. But the `activeElement` will be a top level drawer component since <p> is not focusable (?).

The solution is to check if the touched element is nested within the active element.